### PR TITLE
Update peerDependencies to match ng 9

### DIFF
--- a/projects/ngx-bootstrap-slider/package.json
+++ b/projects/ngx-bootstrap-slider/package.json
@@ -16,8 +16,8 @@
     "bootstrap-slider": "^10.2.0"
   },
   "peerDependencies": {
-    "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
-    "@angular/core": "^6.0.0-rc.0 || ^6.0.0"
+    "@angular/common": "^9.0.0-rc.0 || ^9.0.0",
+    "@angular/core": "^9.0.0-rc.0 || ^9.0.0"
   },
   "ngPackage": {
     "whitelistedNonPeerDependencies": [


### PR DESCRIPTION
Fixes #18

When the project was update to ng 9, the peerDependencies were still pointing to ng 6. In order to allow folks to use ng 9 with ngx bootstrap slider the peerDependencies should be corrected.

Otherwise, folks get a warning that there may be incompatibilities.